### PR TITLE
Enable reading input from either stdin or argument

### DIFF
--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -15,10 +15,10 @@
 package cmd
 
 import (
-  "bufio"
+	"bufio"
 	"fmt"
 	"net/url"
-  "os"
+	"os"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/encode.go
+++ b/cmd/encode.go
@@ -15,8 +15,10 @@
 package cmd
 
 import (
+  "bufio"
 	"fmt"
 	"net/url"
+  "os"
 
 	"github.com/spf13/cobra"
 )
@@ -25,9 +27,15 @@ var encodeCmd = &cobra.Command{
 	Use:   "encode STRING",
 	Short: "URL-encode an input string",
 	Long:  `That's it. URL-encode a string.`,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input := args[0]
+		input := ""
+		if len(args) < 1 {
+			in := bufio.NewReader(os.Stdin)
+			input, _ = in.ReadString('\n')
+		} else {
+			input = args[0]
+		}
 
 		fmt.Println(url.QueryEscape(input))
 	},


### PR DESCRIPTION
Enables reading of input from `stdin` for the `encode` command.

Example behavior below:

![image](https://user-images.githubusercontent.com/7764106/49556483-fbbb2780-f8d1-11e8-962d-51e4f4048853.png)

Addresses [this issue](https://github.com/juicemia/url/issues/4) 😘 